### PR TITLE
Script run with its 'pre' and  'post' scripts, if exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "more-monkeys-dreams":
       "echo Monkeys dreams 2 things : $2 and $1, sometimes it $*",
     "monkeys-knows-nothing": "echo Monkeys $1 $2 $3 $4 $5",
+    "premonkey-ride": "echo Ride on",
+    "monkey-ride": "echo Go monkey!",
+    "postmonkey-ride": "echo Ride off",
     "fail": "exit 1",
     "precommit": "pretty-quick --staged"
   },

--- a/test.js
+++ b/test.js
@@ -42,7 +42,7 @@ describe("At end arguments", function() {
       .run("./nsrun.js")
       .stdout(
         [
-          "10 scripts in ./package.json:",
+          "13 scripts in ./package.json:",
           " * test",
           " * monkey-facts",
           " * more-monkey-facts",
@@ -51,6 +51,9 @@ describe("At end arguments", function() {
           " * monkeys-dreams",
           " * more-monkeys-dreams",
           " * monkeys-knows-nothing",
+          " * premonkey-ride",
+          " * monkey-ride",
+          " * postmonkey-ride",
           " * fail",
           " * precommit"
         ].join("\n")
@@ -105,4 +108,16 @@ describe("Positionned arguments", function() {
       .code(1)
       .end(done);
   });
+});
+
+describe("Run pre and post scripts" ,function(){
+
+    it("runs the scripts with pre and post scripts", function (done) {
+        nixt()
+        .run("./nsrun.js monkey-ride")
+        .stdout("Ride on\nGo monkey!\nRide off")
+        .stderr("")
+        .code(0)
+        .end(done);
+    });
 });


### PR DESCRIPTION
Hello,

Fixed a missing part to be more conform to npm run-script process.

= Pre-run and Post-run process.

From '$ npm help 7 scripts'
"...
Additionally,  arbitrary scripts can be executed by running npm run-script <stage>. Pre and post commands with matching names will be run for those as well (e.g. premyscript, myscript, postmyscript).
..."

= About the arguments.

From '$ npm help run'
extract : 
"...
The arguments will only be passed to the script specified after npm run and not to any pre or post script.
..."